### PR TITLE
Adding Catalina to supported OS. Update this checker for Cytoscape 3.8.0

### DIFF
--- a/system-checker/linux.sh
+++ b/system-checker/linux.sh
@@ -130,8 +130,8 @@ if [[ $JAVA_HOME != "" ]]; then
     echo " - Pass: JAVA_HOME found: $JAVA_HOME"
 else
     echo -e "\e[31mError: \$JAVA_HOME is not set.\e[m\n"
-    echo -e "If you don't have Java yet, please download JDK from Oracle web site:\n"
-    echo -e "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html\n"
+    echo -e "If you don't have Java yet, please download and install a compatible JDK such as AdoptOpenJDK:\n"
+    echo -e "https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot\n"
     echo -e "\e[31mDon't forget to select correct version.\e[m"
     echo -e "Your machine type is: \e[31m$machine_type\e[m"
     pass=false

--- a/system-checker/linux.sh
+++ b/system-checker/linux.sh
@@ -14,8 +14,8 @@ SUPPORTED_DISTRIBUTIONS=("ubuntu" "centos" "fedora")
 
 # Supported versions for each platform
 UBUNTU_VERSIONS=("14.04" "14.10" "15.04" "15.10" "16.04" "16.10" "17 04" "17 10" "18.04" "18.10")
-CENTOS_VERSIONS=("6" "7")
-FEDORA_VERSIONS=("24" "25" "26")
+CENTOS_VERSIONS=("6" "6.1" "6.2" "6.3" "6.4" "6.5" "6.6" "6.7" "6.8" "6.9" "6.10" "7" "7.0.1406" "7.1.1503" "7.2.1511" "7.3.1611" "7.4.1708" "7.5.1804" "7.6.1810" "7.7.1908" "8" "8.0.1905" "8.1.1911")
+FEDORA_VERSIONS=("24" "25" "26" "27" "28" "29" "30" "31" "32")
 
 # Supported Java verisons
 SUPPORTED_JAVA_VERSIONS=("11")
@@ -33,9 +33,16 @@ echo -e "\n\e[31m##### Cytoscape System Requirements Checker for Linux #####\e[m
 echo -e " - Target Cytoscape version: \e[36m$CYTOSCAPE_VERSION\e[m"
 echo -e " - Your Shell: \e[36m$shell\e[m"
 
-# Extract major version
-distribution=$(lsb_release -si)
-os_version=$(lsb_release -sr)
+which lsb_release > /dev/null 2>&1
+if [ $? -eq 0 ] ; then
+    # Extract major version
+    distribution=$(lsb_release -si)
+    os_version=$(lsb_release -sr)
+else 
+    # unable to get os information so just set these fields to "unknown"
+    distribution="unknown"
+    os_version="unknown"
+fi
 
 # Check distribution
 echo -e "\n\e[;1m===== Checking Distribution =====\e[m\n"
@@ -59,9 +66,16 @@ if [ "$os_pass" -eq 1 ]
 then
     echo -e "\e[36;1m - Pass: Distribution = $distribution\e[m"
 else
-    echo -e "\n\e[31mWARNING: This Linux distribution is not officially supported: $distribution\e[m" 1>&2
-    echo "Cytoscape might work with this machine, but not tested."
-    echo "Please use any of the following distributions if possible: [${SUPPORTED_DISTRIBUTIONS[@]}]"
+    # if lsb_release is not installed $distribution will be set to "unknown"
+    # so let user know they should install lsb_release
+    if [ "$distribution" == "unknown" ] ; then
+        echo -e "\n\e[31mERROR: Unable to determine distribution. Please install lsb_release command.\e[m\n"
+    else
+        echo -e "\n\e[31mWARNING: This Linux distribution is not officially supported: $distribution\e[m" 1>&2
+    
+        echo "Cytoscape might work with this machine, but not tested."
+        echo "Please use any of the following distributions if possible: [${SUPPORTED_DISTRIBUTIONS[@]}]"
+    fi
     pass=false
 fi
 

--- a/system-checker/linux.sh
+++ b/system-checker/linux.sh
@@ -4,7 +4,7 @@
 ####################################
 
 # Target Cytoscape version for this script
-CYTOSCAPE_VERSION="3.7.2"
+CYTOSCAPE_VERSION="3.8.0"
 
 # Cytoscpae App Store location
 APP_STORE_URL="apps.cytoscape.org"
@@ -18,7 +18,7 @@ CENTOS_VERSIONS=("6" "7")
 FEDORA_VERSIONS=("24" "25" "26")
 
 # Supported Java verisons
-SUPPORTED_JAVA_VERSIONS=("1.8.0")
+SUPPORTED_JAVA_VERSIONS=("11")
 
 # Error cheking flag
 pass=true
@@ -108,9 +108,9 @@ fi
 # Test 2: Try java -version command
 echo -e "\n\e[;1m===== Checking Java Version =====\e[m\n"
 
-java_version_original=$(java -version 2>&1 | grep "java version")
+java_version_original=$(java -version 2>&1 | grep "openjdk version")
 java_version=$(echo $java_version_original | awk 'NR==1{gsub(/"/,""); print $3}')
-java_major_version=$(echo $java_version | awk -F'_' '{print $1}')
+java_major_version=$(echo $java_version | awk -F'.' '{print $1}')
 
 if [[ $java_major_version == ${SUPPORTED_JAVA_VERSIONS[0]} ]]
 then
@@ -147,12 +147,11 @@ ping_pass=true
 host $APP_STORE_URL || echo -e "\e[31mError: Could not resolve $APP_STORE_URL\e[m\n"; ping_pass=false
 
 if [[ $ping_pass ]];then
-    ping_result=$(ping -c $NUM_TRY -t 15 $APP_STORE_URL | grep loss)
-    num_success=$(echo $ping_result | awk '{print $4}')
+    curl_result=$(curl -I https://apps.cytoscape.org | awk 'NR==1{print $2}')
+   
+    echo -e "\n\e[36m - Result: $curl_result\e[m"
 
-    echo -e "\n\e[36m - Result: $ping_result\e[m"
-
-    if [[ $num_success -eq $NUM_TRY ]]; then
+    if [[ $curl_result -eq "200" ]]; then
         echo -e "\e[36m - Success!"
     else
         echo -e "\e[31mError: Seems connection to App Store is unstable.\e[m\n"

--- a/system-checker/mac.sh
+++ b/system-checker/mac.sh
@@ -5,13 +5,13 @@
 ####################################
 
 # Target Cytoscape version for this script
-CYTOSCAPE_VERSION="3.7.2"
+CYTOSCAPE_VERSION="3.8.0"
 
 # Supported Mac OS versions
-SUPPORTED_OS_VERSIONS=("10.11" "10.12" "10.13" "10.14")
+SUPPORTED_OS_VERSIONS=("10.11" "10.12" "10.13" "10.14" "10.15")
 
 # Supported Java verisons
-SUPPORTED_JAVA_VERSIONS=("1.8.0")
+SUPPORTED_JAVA_VERSIONS=("11")
 
 # Default location for Oracle JDK.
 ORACLE_VM_LOCATION="/Library/Java/JavaVirtualMachines"
@@ -52,7 +52,7 @@ fi
 # Check Java Version
 
 # Test 1: Check Oracle Java Machine
-jvms=$(find $ORACLE_VM_LOCATION -name jdk1.8.0* -type d)
+jvms=$(find $ORACLE_VM_LOCATION -name jdk-11.0* -type d)
 jvm_test=$(echo $jvms | awk '{if(NF>=1){print 1}else{print 0}}')
 
 if [[ $jvm_test -eq 1 ]]; then
@@ -62,21 +62,21 @@ if [[ $jvm_test -eq 1 ]]; then
 else
     echo "- Fail: No Oracle JDK found.  Please download and install Oracle JDK:"
     echo "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html"
-    exit 1
+#    exit 1
 fi
 
 # Test 2: Try java -version command
 java_version_original=$(java -version 2>&1)
 java_version=$(echo $java_version_original | awk 'NR==1{gsub(/"/,""); print $3}')
 
-java_major_version=$(echo $java_version | awk -F'_' '{print $1}')
+java_major_version=$(echo $java_version | awk -F'\.' '{print $1}')
 
 if [[ $java_major_version == ${SUPPORTED_JAVA_VERSIONS[0]} ]]
 then
     echo " - Pass: Current Java Version = $java_version"
 else
     echo "Fail: Java is not reachable."
-    echo "Try re-installing Java 8."
+    echo "Try re-installing Java 11."
     exit 1
 fi
 
@@ -86,28 +86,29 @@ if [[ $JAVA_HOME != "" ]]; then
 else
     echo "JAVA_HOME is not set."
     echo "Please add the following to your .${shell}rc file:"
-    echo "export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_*.jdk/Contents/Home"
-    echo "where * is the latest Java 8 update number."
+    echo "export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-11.0_*.jdk/Contents/Home"
+    echo "where * is the latest Java 11 update number."
     echo "And then type 'source ~/.${shell}rc'"
     exit 1
 fi
 
 # Test 4: Connect to App Store
+
 NUM_TRY=5
 echo "Checking connection to Cytoscape App Store..."
-ping_result=$(ping -c $NUM_TRY -t 15 apps.cytoscape.org | grep loss)
+#ping_result=$(ping -c $NUM_TRY -t 15 apps.cytoscape.org | grep loss)
 
-num_success=$(echo $ping_result | awk '{print $4}')
+#num_success=$(echo $ping_result | awk '{print $4}')
 
-echo $ping_result
+#echo $ping_result
 
-if [[ $num_success -eq $NUM_TRY ]]; then
+APPSTORE=$(curl -I https://apps.cytoscape.org | awk 'NR==1{print $2}')
+
+if [[ $APPSTORE -eq "200" ]]; then
     echo "Done!  You are ready to run Cytoscape $CYTOSCAPE_VERSION"
 else
-    echo "Looks connection to App Store is unstable."
+    echo "https connection to App Store at https://apps.cytoscape.org is not reachable."
     echo "Please check firewall setting from System Preference."
-    echo "traceroute result:"
-    traceroute apps.cytoscape.org
     exit 1
 fi
 

--- a/system-checker/mac.sh
+++ b/system-checker/mac.sh
@@ -60,8 +60,8 @@ if [[ $jvm_test -eq 1 ]]; then
     echo ""
     echo $jvms | awk '{gsub(/ /, "\n", $0);print}'
 else
-    echo "- Fail: No Oracle JDK found.  Please download and install Oracle JDK:"
-    echo "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html"
+    echo "- Fail: No JDK found.  Please download and install a compatible JDK, such as AdoptOpenJDK:"
+    echo "https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot"
 #    exit 1
 fi
 

--- a/system-checker/windows.bat
+++ b/system-checker/windows.bat
@@ -15,7 +15,7 @@ set MAX_JAVA_VERSION=11
 set MAX_JAVA_VERSION_STR=11
 
 REM Recommended link to download Java
-set JAVA_DOWNLOAD=http://java.com/en/download/manual.jsp
+set JAVA_DOWNLOAD=https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot
 
 REM Error checking flags
 set pass=true

--- a/system-checker/windows.bat
+++ b/system-checker/windows.bat
@@ -3,16 +3,16 @@
 REM This is a handy reference for this scripting language: https://technet.microsoft.com/en-us/library/cc754335(v=ws.11).aspx
 
 REM Target Cytoscape version for this script
-set CYTOSCAPE_VERSION=3.7.2
+set CYTOSCAPE_VERSION=3.8.0
 
 REM Cytoscpae App Store location
 set APP_STORE_URL=apps.cytoscape.org
 
 REM Minimal Java version
-set MIN_JAVA_VERSION=8
-set MIN_JAVA_VERSION_STR=8
-set MAX_JAVA_VERSION=8
-set MAX_JAVA_VERSION_STR=8
+set MIN_JAVA_VERSION=11
+set MIN_JAVA_VERSION_STR=11
+set MAX_JAVA_VERSION=11
+set MAX_JAVA_VERSION_STR=11
 
 REM Recommended link to download Java
 set JAVA_DOWNLOAD=http://java.com/en/download/manual.jsp
@@ -27,7 +27,6 @@ set appstore_pass=true
 
 REM Timeout values
 set TRACERT_TIMEOUT=30000
-set PING_TIMEOUT=30000
 
 echo.
 echo Cytoscape System Requirements Checker for Windows
@@ -82,11 +81,17 @@ if "%JAVA_HOME%" == "" (
 
 REM Test for Java version ... could look like 1.8.0_181 or 9+142
 REM ------------------------------------------------------------
-for /f tokens^=2-5^ delims^=.-_+^" %%j in ('java -fullversion 2^>^&1') do set "jver=%%j%%k%%l%%m"
-set jmajorver=%jver:~0,1%
-if "%jmajorver%" EQU "1" (
-	set jmajorver=%jver:~1,1%
+for /f tokens^=2-5^ delims^=.-_+^" %%j in ('java -fullversion 2^>^&1') do (
+	set jver[0]=%%j
+	set jver[1]=%%k
+	set jver[2]=%%l
+	set jver[3]=%%m
 )
+set jmajorver=%jver[0]%
+if "%jmajorver%" EQU "1" (
+	set jmajorver=%jver[1]%
+)
+echo Your Java Major version is %jmajorver%
 
 if %jmajorver% LSS %MIN_JAVA_VERSION% (
     set pass=false
@@ -107,31 +112,15 @@ if %jmajorver% GTR %MAX_JAVA_VERSION% (
     echo.
 )
 
-
-REM Test if Java 64 bit
-REM -------------------
-java -d64 -version >nul 2>&1
-if %errorlevel% NEQ 0 (
-    set java64bit_pass=false
-    if %sys64bit_pass% == true (
-        set pass=false
-    )
-    echo Your Java is 32 bit
-    echo.
-) else (
-    echo Your Java is 64 bit as recommended
-    echo.
-)
-
 :appcheck
 
 REM Test for "app" store
 REM --------------------
-ping -n 1 -w %PING_TIMEOUT% %APP_STORE_URL% | find "TTL=" >nul
+curl -I %APP_STORE_URL% | find "200 OK" >nul
 if %errorlevel% NEQ 0 (
     set pass=false
     set appstore_pass=false
-    echo Problem: The "app" store at %APP_STORE_URL% is not reachable with a timeout of %PING_TIMEOUT%ms
+    echo Problem: The "app" store at %APP_STORE_URL% is not reachable
     echo.
 ) else (
     echo The "app" store at %APP_STORE_URL% is reachable


### PR DESCRIPTION
Modified checker to 

1. support Catalina
2. Requires Java 11
3. Check app store connectivity through https.